### PR TITLE
end_bswap64(): type fix

### DIFF
--- a/endianness.h
+++ b/endianness.h
@@ -151,7 +151,7 @@ static __inline uint32_t end_bswap32(uint32_t __x)
 
 static __inline uint64_t end_bswap64(uint64_t __x)
 {
-        return ((end_bswap32(__x)+0ULL)<<32) | (end_bswap32(__x>>32));
+        return ((end_bswap32((uint32_t)__x)+0ULL)<<32) | (end_bswap32(__x>>32));
 }
 
 static __inline uint16_t end_net2host16(uint16_t net_number)


### PR DESCRIPTION
This patch fixes a warning of loss of information caused by the implicit conversion of uint64_t to uint32_t.