### PR TITLE
Big refactoring

### DIFF
--- a/endianness.h
+++ b/endianness.h
@@ -2,40 +2,82 @@
 #define ENDIANNESS_H
 
 /* Public domain implementation for endianness detection and byte ordering on
-   several platforms. In case the concept of public domain does not exist
-   under your jurisdiction, you can consider it to be dual licensed
-   under the MIT, Apache and WTFPL licenses.
+	several platforms. In case the concept of public domain does not exist
+	under your jurisdiction, you can consider it to be dual licensed
+	under the MIT, Apache and WTFPL licenses.
 
-   Grab it and drop it into your project, include it and use
-   the following macros to determine endianness:
+	Grab it and drop it into your project, include it and use
+	the following macros to determine endianness:
 
-   ENDIANNESS_LE, ENDIANNESS_BE
+	ENDIANNESS_LE, ENDIANNESS_BE
 
-   e.g. #if ENDIANNESS_LE ...
+	e.g. #if ENDIANNESS_LE ...
 
-   or, even nicer without littering your code with #ifdefs:
+	or, even nicer without littering your code with #ifdefs:
 
-   if (ENDIANNESS_BE) { big_endian_code(); } else { little_endian_code(); }
+	if (ENDIANNESS_BE) { big_endian_code(); } else { little_endian_code(); }
 
-   ... since the compiler can optimize away unused branches, this makes your
-   code easier to read while not loosing any of the advantage of using
-   conditional compilation, plus you get a free compile-time check of the
-   unused code path (rarely used conditonally compiled code paths often get
-   defunct over time if nobody checks them all the time).
+	... since the compiler can optimize away unused branches, this makes your
+	code easier to read while not loosing any of the advantage of using
+	conditional compilation, plus you get a free compile-time check of the
+	unused code path (rarely used conditonally compiled code paths often get
+	defunct over time if nobody checks them all the time).
 
-   To debug this header yourself, you can define ENDIANNESS_DEBUG to see
-   warnings from where we take the defs for the specific target.
+	To debug this header yourself, you can define ENDIANNESS_DEBUG to see
+	warnings from where we take the defs for the specific target.
 
-   If you need only the conversion functions from big to little endian
-   and vice versa, you may want to #define ENDIANNESS_PORTABLE_CONVERSION
-   prior to including this header. That way, when the endiannes can't be
-   determined at compile time, the code will fallback to a slower,
-   but portable version of those functions.
-   However, if using it, it's not guaranteed that ENDIANNESS_LE/BE
-   will be defined.
-   Most people however need only the conversion functions in their code,
-   so if you stick to them you can safely turn the portable conversion on.
+	If you need only the conversion functions from big to little endian
+	and vice versa, you may want to #define ENDIANNESS_PORTABLE_CONVERSION
+	prior to including this header. That way, when the endiannes can't be
+	determined at compile time, the code will fallback to a slower,
+	but portable version of those functions.
+	However, if using it, it's not guaranteed that ENDIANNESS_LE/BE
+	will be defined.
+	Most people however need only the conversion functions in their code,
+	so if you stick to them you can safely turn the portable conversion on.
 */
+
+// Endianness indicators
+#define ENDIANNESS_LE	ENDIANNESS_LE_IMPL
+#define ENDIANNESS_BE	ENDIANNESS_BE_IMPL
+
+// Network order conversions
+#define end_ntoh16(x)	end_be16toh_impl(x)
+#define end_ntoh32(x)	end_be32toh_impl(x)
+#define end_ntoh64(x)	end_be64toh_impl(x)
+
+#define end_hton16(x)	end_htobe16_impl(x)
+#define end_hton32(x)	end_htobe32_impl(x)
+#define end_hton64(x)	end_htobe64_impl(x)
+
+#define end_htonl(x)	end_htobe32_impl(x)
+#define end_htons(x)	end_htobe16_impl(x)
+
+#define end_ntohl(x)	end_be32toh_impl(x)
+#define end_ntohs(x)	end_be16toh_impl(x)
+
+// Big-endian conversions
+#define end_be16toh(x)	end_be16toh_impl(x)
+#define end_be32toh(x)	end_be32toh_impl(x)
+#define end_be64toh(x)	end_be64toh_impl(x)
+
+#define end_htobe16(x)	end_htobe16_impl(x)
+#define end_htobe32(x)	end_htobe32_impl(x)
+#define end_htobe64(x)	end_htobe64_impl(x)
+
+// Little-endian conversions
+#define end_le16toh(x)	end_le16toh_impl(x)
+#define end_le32toh(x)	end_le32toh_impl(x)
+#define end_le64toh(x)	end_le64toh_impl(x)
+
+#define end_htole16(x)	end_htole16_impl(x)
+#define end_htole32(x)	end_htole32_impl(x)
+#define end_htole64(x)	end_htole64_impl(x)
+
+// Byte swap functions
+#define end_bswap16(x)	end_bswap16_impl(x)
+#define end_bswap32(x)	end_bswap32_impl(x)
+#define end_bswap64(x)	end_bswap64_impl(x)
 
 /* This should catch all modern GCCs and Clang */
 #if (defined __BYTE_ORDER__) && (defined __ORDER_LITTLE_ENDIAN__)
@@ -43,95 +85,98 @@
 #  warning "Taking endiannes from built-in __BYTE_ORDER__"
 # endif
 # if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#  define ENDIANNESS_LE 1
-#  define ENDIANNESS_BE 0
+#  define ENDIANNESS_LE_IMPL 1
+#  define ENDIANNESS_BE_IMPL 0
 # elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#  define ENDIANNESS_LE 0
-#  define ENDIANNESS_BE 1
+#  define ENDIANNESS_LE_IMPL 0
+#  define ENDIANNESS_BE_IMPL 1
 # endif
 /* Try to derive from arch/compiler-specific macros */
 #elif defined(_X86_) || defined(__x86_64__) || defined(__i386__) || \
-      defined(__i486__) || defined(__i586__) || defined(__i686__) || \
-      defined(__MIPSEL) || defined(_MIPSEL) || defined(MIPSEL) || \
-      defined(__ARMEL__) || \
-      (defined(__LITTLE_ENDIAN__) && __LITTLE_ENDIAN__ == 1) || \
-      (defined(_LITTLE_ENDIAN) && _LITTLE_ENDIAN == 1) || \
-      defined(_M_IX86) || defined(_M_AMD64) /* MSVC */
+		defined(__i486__) || defined(__i586__) || defined(__i686__) || \
+		defined(__MIPSEL) || defined(_MIPSEL) || defined(MIPSEL) || \
+		defined(__ARMEL__) || \
+		(defined(__LITTLE_ENDIAN__) && __LITTLE_ENDIAN__ == 1) || \
+		(defined(_LITTLE_ENDIAN) && _LITTLE_ENDIAN == 1) || \
+		defined(_M_IX86) || defined(_M_AMD64) /* MSVC */
 # ifdef ENDIANNESS_DEBUG
 #  warning "Detected Little Endian target CPU"
 # endif
-# define ENDIANNESS_LE 1
-# define ENDIANNESS_BE 0
+# define ENDIANNESS_LE_IMPL 1
+# define ENDIANNESS_BE_IMPL 0
 #elif defined(__MIPSEB) || defined(_MIPSEB) || defined(MIPSEB) || \
-      defined(__MICROBLAZEEB__) || defined(__ARMEB__) || \
-      (defined(__BIG_ENDIAN__) && __BIG_ENDIAN__ == 1) || \
-      (defined(_BIG_ENDIAN) && _BIG_ENDIAN == 1)
+		defined(__MICROBLAZEEB__) || defined(__ARMEB__) || \
+		(defined(__BIG_ENDIAN__) && __BIG_ENDIAN__ == 1) || \
+		(defined(_BIG_ENDIAN) && _BIG_ENDIAN == 1)
 # ifdef ENDIANNESS_DEBUG
 #  warning "Detected Big Endian target CPU"
 # endif
-# define ENDIANNESS_LE 0
-# define ENDIANNESS_BE 1
+# define ENDIANNESS_LE_IMPL 0
+# define ENDIANNESS_BE_IMPL 1
 /* Try to get it from a header */
 #else
 # if defined(__linux)
 #  ifdef ENDIANNESS_DEBUG
-#   warning "Taking endiannes from endian.h"
+#	warning "Taking endiannes from endian.h"
 #  endif
 #  include <endian.h>
 # else
 #  ifdef ENDIANNESS_DEBUG
-#   warning "Taking endiannes from machine/endian.h"
+#	warning "Taking endiannes from machine/endian.h"
 #  endif
 #  include <machine/endian.h>
 # endif
 #endif
 
-#ifndef ENDIANNESS_LE
-# undef ENDIANNESS_BE
+#ifndef ENDIANNESS_LE_IMPL
+# undef ENDIANNESS_BE_IMPL
 # if defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
 #  if __BYTE_ORDER == __LITTLE_ENDIAN
-#   define ENDIANNESS_LE 1
-#   define ENDIANNESS_BE 0
+#	define ENDIANNESS_LE_IMPL 1
+#	define ENDIANNESS_BE_IMPL 0
 #  elif __BYTE_ORDER == __BIG_ENDIAN
-#   define ENDIANNESS_LE 0
-#   define ENDIANNESS_BE 1
+#	define ENDIANNESS_LE_IMPL 0
+#	define ENDIANNESS_BE_IMPL 1
 #  endif
 # elif defined(BYTE_ORDER) && defined(LITTLE_ENDIAN)
 #  if BYTE_ORDER == LITTLE_ENDIAN
-#   define ENDIANNESS_LE 1
-#   define ENDIANNESS_BE 0
+#	define ENDIANNESS_LE_IMPL 1
+#	define ENDIANNESS_BE_IMPL 0
 #  elif BYTE_ORDER == BIG_ENDIAN
-#   define ENDIANNESS_LE 0
-#   define ENDIANNESS_BE 1
+#	define ENDIANNESS_LE_IMPL 0
+#	define ENDIANNESS_BE_IMPL 1
 #  endif
 # endif
 #endif
 
-/* In case the user passed one of -DENDIANNESS_LE or BE in CPPFLAS,
-   set the second one too */
-#if defined(ENDIANNESS_LE) && !(defined(ENDIANNESS_BE))
-# if ENDIANNESS_LE == 0
-#  define ENDIANNESS_BE 1
+/* In case the user passed one of -DENDIANNESS_LE_IMPL or BE in CPPFLAS,
+	set the second one too */
+#if defined(ENDIANNESS_LE_IMPL) && !(defined(ENDIANNESS_BE_IMPL))
+# if ENDIANNESS_LE_IMPL == 0
+#  define ENDIANNESS_BE_IMPL 1
 # else
-#  define ENDIANNESS_BE 0
+#  define ENDIANNESS_BE_IMPL 0
 # endif
-#elif defined(ENDIANNESS_BE) && !(defined(ENDIANNESS_LE))
-# if ENDIANNESS_BE == 0
-#  define ENDIANNESS_LE 1
+#elif defined(ENDIANNESS_BE_IMPL) && !(defined(ENDIANNESS_LE_IMPL))
+# if ENDIANNESS_BE_IMPL == 0
+#  define ENDIANNESS_LE_IMPL 1
 # else
-#  define ENDIANNESS_LE 0
+#  define ENDIANNESS_LE_IMPL 0
 # endif
 #endif
 
-#if !(defined(ENDIANNESS_LE)) && !(defined(ENDIANNESS_PORTABLE_CONVERSION))
-# error "Sorry, we couldn't detect endiannes for your system! Please set -DENDIANNESS_LE=1 or 0 using your CPPFLAGS/CFLAGS and open an issue for your system on https://github.com/rofl0r/endianness.h - Thanks!"
+#if !(defined(ENDIANNESS_LE_IMPL)) && !(defined(ENDIANNESS_PORTABLE_CONVERSION))
+# error "Sorry, we couldn't detect endianness for your system! Please set " \
+		"-DENDIANNESS_LE_IMPL=1 or 0 using your CPPFLAGS/CFLAGS and open an " \
+		"issue for your system on https://github.com/rofl0r/endianness.h - " \
+		"Thanks!"
 #endif
 
 #ifdef ENDIANNESS_DEBUG
-# if ENDIANNESS_LE == 1
+# if ENDIANNESS_LE_IMPL == 1
 #  warning "Detected Little Endian target CPU"
 # endif
-# if ENDIANNESS_BE == 1
+# if ENDIANNESS_BE_IMPL == 1
 #  warning "Detected BIG Endian target CPU"
 # endif
 #endif
@@ -139,19 +184,20 @@
 #include <stdint.h>
 #include <limits.h>
 
-static __inline uint16_t end_bswap16(uint16_t __x)
+static __inline uint16_t end_bswap16_impl(uint16_t __x)
 {
-        return (__x<<8) | (__x>>8);
+		return (__x<<8) | (__x>>8);
 }
 
-static __inline uint32_t end_bswap32(uint32_t __x)
+static __inline uint32_t end_bswap32_impl(uint32_t __x)
 {
-        return (__x>>24) | (__x>>8&0xff00) | (__x<<8&0xff0000) | (__x<<24);
+		return (__x>>24) | (__x>>8&0xff00) | (__x<<8&0xff0000) | (__x<<24);
 }
 
-static __inline uint64_t end_bswap64(uint64_t __x)
+static __inline uint64_t end_bswap64_impl(uint64_t __x)
 {
-        return ((end_bswap32((uint32_t)__x)+0ULL)<<32) | (end_bswap32(__x>>32));
+		return ((end_bswap32_impl((uint32_t)__x)+0ULL)<<32)
+			  | (end_bswap32_impl(__x>>32));
 }
 
 static __inline uint16_t end_net2host16(uint16_t net_number)
@@ -220,53 +266,55 @@ static __inline uint64_t end_host2net64(uint64_t native_number)
 	return result;
 }
 
-#if ENDIANNESS_LE+0 == 1
-# define end_htobe16(x) end_bswap16(x)
-# define end_be16toh(x) end_bswap16(x)
-# define end_htobe32(x) end_bswap32(x)
-# define end_be32toh(x) end_bswap32(x)
-# define end_htobe64(x) end_bswap64(x)
-# define end_be64toh(x) end_bswap64(x)
-# define end_htole16(x) (uint16_t)(x)
-# define end_le16toh(x) (uint16_t)(x)
-# define end_htole32(x) (uint32_t)(x)
-# define end_le32toh(x) (uint32_t)(x)
-# define end_htole64(x) (uint64_t)(x)
-# define end_le64toh(x) (uint64_t)(x)
-#elif ENDIANNESS_BE+0 == 1
-# define end_htobe16(x) (uint16_t)(x)
-# define end_be16toh(x) (uint16_t)(x)
-# define end_htobe32(x) (uint32_t)(x)
-# define end_be32toh(x) (uint32_t)(x)
-# define end_htobe64(x) (uint64_t)(x)
-# define end_be64toh(x) (uint64_t)(x)
-# define end_htole16(x) end_bswap16(x)
-# define end_le16toh(x) end_bswap16(x)
-# define end_htole32(x) end_bswap32(x)
-# define end_le32toh(x) end_bswap32(x)
-# define end_htole64(x) end_bswap64(x)
-# define end_le64toh(x) end_bswap64(x)
+#if ENDIANNESS_LE_IMPL+0 == 1
+# define end_htobe16_impl(x) end_bswap16_impl(x)
+# define end_htobe32_impl(x) end_bswap32_impl(x)
+# define end_htobe64_impl(x) end_bswap64_impl(x)
+
+# define end_be16toh_impl(x) end_bswap16_impl(x)
+# define end_be32toh_impl(x) end_bswap32_impl(x)
+# define end_be64toh_impl(x) end_bswap64_impl(x)
+
+# define end_htole16_impl(x) (uint16_t)(x)
+# define end_htole32_impl(x) (uint32_t)(x)
+# define end_htole64_impl(x) (uint64_t)(x)
+
+# define end_le16toh_impl(x) (uint16_t)(x)
+# define end_le32toh_impl(x) (uint32_t)(x)
+# define end_le64toh_impl(x) (uint64_t)(x)
+#elif ENDIANNESS_BE_IMPL+0 == 1
+# define end_htobe16_impl(x) (uint16_t)(x)
+# define end_htobe32_impl(x) (uint32_t)(x)
+# define end_htobe64_impl(x) (uint64_t)(x)
+
+# define end_be16toh_impl(x) (uint16_t)(x)
+# define end_be32toh_impl(x) (uint32_t)(x)
+# define end_be64toh_impl(x) (uint64_t)(x)
+
+# define end_htole16_impl(x) end_bswap16_impl(x)
+# define end_htole32_impl(x) end_bswap32_impl(x)
+# define end_htole64_impl(x) end_bswap64_impl(x)
+
+# define end_le16toh_impl(x) end_bswap16_impl(x)
+# define end_le32toh_impl(x) end_bswap32_impl(x)
+# define end_le64toh_impl(x) end_bswap64_impl(x)
 #else
 /* Resort to slower, but neutral code */
-# define end_htobe16(x)  end_host2net16(x)
-# define end_be16toh(x)  end_net2host16(x)
-# define end_htobe32(x)  end_host2net32(x)
-# define end_be32toh(x)  end_net2host32(x)
-# define end_htobe64(x)  end_host2net64(x)
-# define end_be64toh(x)  end_net2host64(x)
-# define end_htole16(x)  end_bswap_16(end_host2net16(x))
-# define end_le16toh(x)  end_bswap_16(end_host2net16(x))
-# define end_htole32(x)  end_bswap_32(end_host2net32(x))
-# define end_le32toh(x)  end_bswap_32(end_host2net32(x))
-# define end_htole64(x)  end_bswap_64(end_host2net64(x))
-# define end_le64toh(x)  end_bswap_64(end_host2net64(x))
-#endif
+# define end_htobe16_impl(x) end_host2net16(x)
+# define end_htobe32_impl(x) end_host2net32(x)
+# define end_htobe64_impl(x) end_host2net64(x)
 
-#define end_ntoh16(x)  end_be16toh(x)
-#define end_hton16(x)  end_htobe16(x)
-#define end_ntoh32(x)  end_be32toh(x)
-#define end_hton32(x)  end_htobe32(x)
-#define end_ntoh64(x)  end_be64toh(x)
-#define end_hton64(x)  end_htobe64(x)
+# define end_be16toh_impl(x) end_net2host16(x)
+# define end_be32toh_impl(x) end_net2host32(x)
+# define end_be64toh_impl(x) end_net2host64(x)
+
+# define end_htole16_impl(x) end_bswap_16(end_host2net16(x))
+# define end_htole32_impl(x) end_bswap_32(end_host2net32(x))
+# define end_htole64_impl(x) end_bswap_64(end_host2net64(x))
+
+# define end_le16toh_impl(x) end_bswap_16(end_host2net16(x))
+# define end_le32toh_impl(x) end_bswap_32(end_host2net32(x))
+# define end_le64toh_impl(x) end_bswap_64(end_host2net64(x))
+#endif
 
 #endif

--- a/test.c
+++ b/test.c
@@ -117,9 +117,11 @@ void executeBigEndianConversionTests()
 	puts("\t# Network order (big-endian) to host:");
 
 	assert(host_16bit == end_ntoh16( *(const uint16_t*)bigEndian));
+	assert(host_16bit == end_ntohs(  *(const uint16_t*)bigEndian));
 	assert(host_16bit == end_be16toh(*(const uint16_t*)bigEndian));
 
 	assert(host_32bit == end_ntoh32( *(const uint32_t*)bigEndian));
+	assert(host_32bit == end_ntohl(  *(const uint32_t*)bigEndian));
 	assert(host_32bit == end_be32toh(*(const uint32_t*)bigEndian));
 
 	assert(host_64bit == end_ntoh64( *(const uint64_t*)bigEndian));
@@ -128,9 +130,11 @@ void executeBigEndianConversionTests()
 
 	puts("\t# Host to network order (big-endian):");
 	assert(*((const uint16_t*)bigEndian) == end_hton16( host_16bit));
+	assert(*((const uint16_t*)bigEndian) == end_htons(  host_16bit));
 	assert(*((const uint16_t*)bigEndian) == end_htobe16(host_16bit));
 
 	assert(*((const uint32_t*)bigEndian) == end_hton32( host_32bit));
+	assert(*((const uint32_t*)bigEndian) == end_htonl(  host_32bit));
 	assert(*((const uint32_t*)bigEndian) == end_htobe32(host_32bit));
 
 	assert(*((const uint64_t*)bigEndian) == end_hton64( host_64bit));

--- a/test.c
+++ b/test.c
@@ -2,25 +2,162 @@
 #include "endianness.h"
 
 #include <stdio.h>
+#include <assert.h>
 
-int main() {
+static void printPlatformEndianness();
+static void executeTests();
 
-#if ENDIANNESS_LE
-#    define STR "little"
-#elif ENDIANNESS_BE
-#    define STR "big"
-#else
-#    error "unknown endianness"
-#endif
+int main()
+{
+	printPlatformEndianness();
+	executeTests();
 
-	puts("this program was compiled for " STR " endian");
+	return 0;
+}
+
+void printPlatformEndianness()
+{
+	#if ENDIANNESS_LE
+	#	define STR "little"
+	#elif ENDIANNESS_BE
+	#	define STR "big"
+	#else
+	#	error "unknown endianness"
+	#endif
+
+	puts("\nThis program was compiled for " STR " endian.");
 
 	if(ENDIANNESS_LE) {
-		puts("yes, the endianness is little!");
+		puts("\tYes, the endianness is little!");
 	} else if(ENDIANNESS_BE) {
-		puts("yes, the endianness is BIG!");
+		puts("\tYes, the endianness is BIG!");
 	} else {
-		puts("this code will never be reached!");
+		puts("\tThis code shall never be reached!");
+	}
+}
+
+static const uint8_t bigEndian[sizeof(uint64_t)] =
+{
+	0xDE, 0xAD,
+	0xBE, 0xEF,
+	0xCA, 0xFE,
+	0xBA, 0xBE
+};
+
+static const size_t bigEndian_count = sizeof(bigEndian) / sizeof(*bigEndian);
+
+static const uint8_t littleEndian[sizeof(uint64_t)] =
+{
+	bigEndian[bigEndian_count - 1],
+	bigEndian[bigEndian_count - 2],
+	bigEndian[bigEndian_count - 3],
+	bigEndian[bigEndian_count - 4],
+	bigEndian[bigEndian_count - 5],
+	bigEndian[bigEndian_count - 6],
+	bigEndian[bigEndian_count - 7],
+	bigEndian[bigEndian_count - 8],
+};
+
+static const size_t littleEndian_count =
+						sizeof(littleEndian)
+						/ sizeof(*littleEndian);
+
+static const uint16_t host_16bit = 0xDEADu;
+static const uint32_t host_32bit = 0xDEADBEEFu;
+static const uint64_t host_64bit = 0xDEADBEEFCAFEBABEu;
+
+
+static void executeBigEndianConversionTests();
+static void executeLittleEndianConversionTests();
+static void printTestData();
+
+void executeTests()
+{
+	puts("\nExecuting conversion tests:");
+	printTestData();
+
+	executeBigEndianConversionTests();
+	executeLittleEndianConversionTests();
+}
+
+void printVarLayout(
+	char const * const name,
+	uint8_t const * const var,
+	size_t size);
+
+#define printVarNameAndLayout(var) \
+	printVarLayout(#var, (const uint8_t*)&var, sizeof(var))
+
+void printTestData()
+{
+	puts("\tTest data:");
+	printVarNameAndLayout(host_64bit);
+	printVarNameAndLayout(littleEndian);
+	printVarNameAndLayout(bigEndian);
+	puts("");
+}
+
+void printVarLayout(
+	char const * const name,
+	uint8_t const * const var,
+	size_t size)
+{
+	printf("\t\t%s:\t", name);
+
+	for(size_t i = 0; i < size; ++i)
+	{
+		printf("%X ", var[i]);
 	}
 
+	puts("");
+}
+
+void executeBigEndianConversionTests()
+{
+	puts("\t# Network order (big-endian) to host:");
+
+	assert(host_16bit == end_ntoh16( *(const uint16_t*)bigEndian));
+	assert(host_16bit == end_be16toh(*(const uint16_t*)bigEndian));
+
+	assert(host_32bit == end_ntoh32( *(const uint32_t*)bigEndian));
+	assert(host_32bit == end_be32toh(*(const uint32_t*)bigEndian));
+
+	assert(host_64bit == end_ntoh64( *(const uint64_t*)bigEndian));
+	assert(host_64bit == end_be64toh(*(const uint64_t*)bigEndian));
+	puts("\t\t OK!");
+
+	puts("\t# Host to network order (big-endian):");
+	assert(*((const uint16_t*)bigEndian) == end_hton16( host_16bit));
+	assert(*((const uint16_t*)bigEndian) == end_htobe16(host_16bit));
+
+	assert(*((const uint32_t*)bigEndian) == end_hton32( host_32bit));
+	assert(*((const uint32_t*)bigEndian) == end_htobe32(host_32bit));
+
+	assert(*((const uint64_t*)bigEndian) == end_hton64( host_64bit));
+	assert(*((const uint64_t*)bigEndian) == end_htobe64(host_64bit));
+	puts("\t\t OK!");
+}
+
+void executeLittleEndianConversionTests()
+{
+	const uint16_t* littleEndian_16bit =
+		(const uint16_t*)&littleEndian[littleEndian_count - sizeof(uint16_t)];
+
+	const uint32_t* littleEndian_32bit =
+		(const uint32_t*)&littleEndian[littleEndian_count - sizeof(uint32_t)];
+
+	const uint64_t* littleEndian_64bit = (const uint64_t*)littleEndian;
+
+	puts("\t# Little-endian to host:");
+	assert(host_16bit == end_le16toh(*littleEndian_16bit));
+	assert(host_32bit == end_le32toh(*littleEndian_32bit));
+	assert(host_64bit == end_le64toh(*littleEndian_64bit));
+
+	puts("\t\t OK!");
+
+	puts("\t# Host to little-endian:");
+	assert(*littleEndian_16bit == end_htole16(host_16bit));
+	assert(*littleEndian_32bit == end_htole32(host_32bit));
+	assert(*littleEndian_64bit == end_htole64(host_64bit));
+	puts("\t\t OK!");
 }


### PR DESCRIPTION
# Split code to API and implementation headers
    
    It was really hard to find, at the first glance, the true API of
    the project.
    
    Restructuring the code to the interface and the implementation
    headers shall help future users get on track faster.

# Extend tests with conversion functions

    Network to host and host to network functions are tested now. 

# Refactor endianness.h
    
    * All API functions have been moved to endianness.h.
    * Postfix "_impl" has been added to the non public functions.
    * Added missing POSIX htons, htonl, ntohl, ntohs functions.
    * Macros have been reorder for readability.
    * Replaced tabs with spaces.
    * Enforced 80 characters line lenght limit.
