### PR TITLE
Test __GLIBC__ for endian.h availability

### DIFF
--- a/endianness.h
+++ b/endianness.h
@@ -73,7 +73,7 @@
 # define ENDIANNESS_BE 1
 /* Try to get it from a header */
 #else
-# if defined(__linux)
+# if defined(__GLIBC__) || defined(__linux)
 #  ifdef ENDIANNESS_DEBUG
 #   warning "Taking endiannes from endian.h"
 #  endif


### PR DESCRIPTION
The `endian.h` header, as well as macros and functions declared in it, are not a part of Linux, but really provided by the **GNU C Library** (GLIBC), so `endianness.h` should test the `__GLIBC__` macro instead, for this feature.
But since the `__GLIBC__` macro is usually not predefined by compiler, but rather in GLIBC's own `features.h` only, there is a small chance that it didn't get defined by the time `endianness.h` get included; for example the user may be including `endianness.h` before any GLIBC headers. The workaround I considered is keeping the original `__linux` macro test, however this is not ideal because it made an assumption that all other C library implementations for Linux must support this nonstandard `endian.h`, in a GLIBC-compatible way.
This change enables using GLIBC `endian.h` to detect byte-order on non-Linux-based GNU systems, where compiler built-in `__BYTE_ORDER__` isn't available for any reason.